### PR TITLE
Fixed linq can't be used to `OscParameterCollection`.

### DIFF
--- a/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
+++ b/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
@@ -263,4 +263,14 @@ public class OscParameterCollectionTests
         pararmeters[Address1] = 60;
         Assert.AreEqual(0, calledCount);
     }
+
+    [Test]
+    public void TestLinq()
+    {
+        var pararmeters = CreateParameterCollectionForTest();
+        pararmeters["/address/to/parameter1"] = 10;
+        pararmeters["/address/to/parameter2"] = 10f;
+        pararmeters["/address/to/parameter3"] = false;
+        Assert.DoesNotThrow(() => pararmeters.OrderBy(v => v.Key));
+    }
 }

--- a/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
+++ b/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
@@ -271,6 +271,6 @@ public class OscParameterCollectionTests
         pararmeters["/address/to/parameter1"] = 10;
         pararmeters["/address/to/parameter2"] = 10f;
         pararmeters["/address/to/parameter3"] = false;
-        Assert.DoesNotThrow(() => pararmeters.OrderBy(v => v.Key));
+        Assert.DoesNotThrow(() => pararmeters.OrderBy(v => v.Key).ToArray());
     }
 }

--- a/src/vrcosclib/Collections/OscParameterCollection.cs
+++ b/src/vrcosclib/Collections/OscParameterCollection.cs
@@ -81,12 +81,13 @@ public class OscParameterCollection : IDictionary<string, object?>, IReadOnlyOsc
 
     void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
     {
-        throw new NotSupportedException();
+        ((ICollection<KeyValuePair<string, object?>>)_items).CopyTo(array, arrayIndex);
     }
     bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item)
     {
-        throw new NotSupportedException();
+        return ((ICollection<KeyValuePair<string, object?>>)_items).Remove(item);
     }
+
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     #endregion
 


### PR DESCRIPTION
Fixed #17