### PR TITLE
Corresponded to .NET Framework.

### DIFF
--- a/src/vrcosclib.Test/Avatar/OscAvatarConfigTests.cs
+++ b/src/vrcosclib.Test/Avatar/OscAvatarConfigTests.cs
@@ -10,6 +10,8 @@ namespace BuildSoft.VRChat.Osc.Avatar.Test;
 [TestOf(typeof(OscAvatarConfig))]
 public class OscAvatarConfigTests
 {
+    public static readonly Random SharedRandom = new();
+
     private const string Id = "avtr_id";
     private const string Name = "avatar";
 
@@ -38,7 +40,7 @@ public class OscAvatarConfigTests
                 {
                     parameters.Clear();
 
-                    int parameterCount = Random.Shared.Next(0, 10);
+                    int parameterCount = SharedRandom.Next(0, 10);
                     for (int k = 0; k < parameterCount; k++)
                     {
                         parameters.Add(new OscAvatarParameterJson($"param{k}", OscType.Float));

--- a/src/vrcosclib.Test/Input/OscInputTests.cs
+++ b/src/vrcosclib.Test/Input/OscInputTests.cs
@@ -13,14 +13,14 @@ public class OscInputTests
     OscServer _server = null!;
 
     public static IEnumerable<TestCaseData> AllOscButtonInput
-        => Enum.GetValues<OscButtonInput>().Select(item => new TestCaseData(item));
+        => Enum.GetValues(typeof(OscButtonInput)).Cast<OscButtonInput>().Select(item => new TestCaseData(item));
     public static IEnumerable<TestCaseData> AllOscAxisInput
-        => Enum.GetValues<OscAxisInput>().Select(item => new TestCaseData(item));
+        => Enum.GetValues(typeof(OscAxisInput)).Cast<OscAxisInput>().Select(item => new TestCaseData(item));
     public static IEnumerable<TestCaseData> OscAxisInputTestCases
     {
         get
         {
-            foreach (var item in Enum.GetValues<OscAxisInput>())
+            foreach (var item in Enum.GetValues(typeof(OscAxisInput)))
             {
                 yield return new(item, 1f) { ExpectedResult = 1f };
                 yield return new(item, 2.5f) { ExpectedResult = 1f };

--- a/src/vrcosclib.Test/TestUtility.cs
+++ b/src/vrcosclib.Test/TestUtility.cs
@@ -98,19 +98,17 @@ public static class TestUtility
 #if NETFRAMEWORK
     public static async Task WaitAsync(this Task task, TimeSpan timeout)
     {
-        task.Start();
-
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
+
         await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
     }
 
     public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
     {
-        task.Start();
-
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
+
         await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
         return task.Result;
     }

--- a/src/vrcosclib.Test/TestUtility.cs
+++ b/src/vrcosclib.Test/TestUtility.cs
@@ -109,7 +109,7 @@ public static class TestUtility
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
 
-        await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
+        await Task.Run(() => { while (!task.IsCompleted) ; }, source.Token);
     }
 
     public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
@@ -125,7 +125,7 @@ public static class TestUtility
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
 
-        await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
+        await Task.Run(() => { while (!task.IsCompleted) ; }, source.Token);
         return task.Result;
     }
 #endif

--- a/src/vrcosclib.Test/TestUtility.cs
+++ b/src/vrcosclib.Test/TestUtility.cs
@@ -106,10 +106,16 @@ public static class TestUtility
         catch (InvalidOperationException)
         {
         }
-        using CancellationTokenSource source = new CancellationTokenSource();
-        source.CancelAfter(timeout);
 
-        await Task.Run(() => { while (!task.IsCompleted) ; }, source.Token);
+        bool isSuccessed = Task.Run(() => { while (task.Status == TaskStatus.Running || task.Status == TaskStatus.WaitingForActivation) ; }).Wait(timeout);
+        if (!isSuccessed)
+        {
+            throw new TimeoutException();
+        }
+        if (task.IsFaulted)
+        {
+            throw task.Exception.InnerException;
+        }
     }
 
     public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
@@ -122,10 +128,16 @@ public static class TestUtility
         catch (InvalidOperationException)
         {
         }
-        using CancellationTokenSource source = new CancellationTokenSource();
-        source.CancelAfter(timeout);
 
-        await Task.Run(() => { while (!task.IsCompleted) ; }, source.Token);
+        bool isSuccessed = Task.Run(() => { while (task.Status == TaskStatus.Running || task.Status == TaskStatus.WaitingForActivation) ; }).Wait(timeout);
+        if (!isSuccessed)
+        {
+            throw new TimeoutException();
+        }
+        if (task.IsFaulted)
+        {
+            throw task.Exception.InnerException;
+        }
         return task.Result;
     }
 #endif

--- a/src/vrcosclib.Test/TestUtility.cs
+++ b/src/vrcosclib.Test/TestUtility.cs
@@ -94,4 +94,25 @@ public static class TestUtility
             Directory.Move(_destDirName, OscUtility.VRChatOscPath);
         }
     }
+
+#if NETFRAMEWORK
+    public static async Task WaitAsync(this Task task, TimeSpan timeout)
+    {
+        task.Start();
+
+        using CancellationTokenSource source = new CancellationTokenSource();
+        source.CancelAfter(timeout);
+        await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
+    }
+
+    public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
+    {
+        task.Start();
+
+        using CancellationTokenSource source = new CancellationTokenSource();
+        source.CancelAfter(timeout);
+        await Task.Run(() => { while (task.IsCompleted) ; }, source.Token);
+        return task.Result;
+    }
+#endif
 }

--- a/src/vrcosclib.Test/TestUtility.cs
+++ b/src/vrcosclib.Test/TestUtility.cs
@@ -98,6 +98,14 @@ public static class TestUtility
 #if NETFRAMEWORK
     public static async Task WaitAsync(this Task task, TimeSpan timeout)
     {
+        // if not running, start task
+        try
+        {
+            task.Start();
+        }
+        catch (InvalidOperationException)
+        {
+        }
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
 
@@ -106,6 +114,14 @@ public static class TestUtility
 
     public static async Task<T> WaitAsync<T>(this Task<T> task, TimeSpan timeout)
     {
+        // if not running, start task
+        try
+        {
+            task.Start();
+        }
+        catch (InvalidOperationException)
+        {
+        }
         using CancellationTokenSource source = new CancellationTokenSource();
         source.CancelAfter(timeout);
 

--- a/src/vrcosclib.Test/Utility/OscAvatarConfigJson.cs
+++ b/src/vrcosclib.Test/Utility/OscAvatarConfigJson.cs
@@ -1,11 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using BuildSoft.VRChat.Osc.Avatar;
+﻿namespace BuildSoft.VRChat.Osc.Test;
 
-namespace BuildSoft.VRChat.Osc.Test;
+public record class OscAvatarConfigJson
+{
+    public string id;
+    public string name;
+    public OscAvatarParameterJson[] parameters;
 
-public record class OscAvatarConfigJson(string id, string name, OscAvatarParameterJson[] parameters);
+    public OscAvatarConfigJson(string id, string name, OscAvatarParameterJson[] parameters)
+    {
+        this.id = id;
+        this.name = name;
+        this.parameters = parameters;
+    }
+}

--- a/src/vrcosclib.Test/Utility/OscAvatarParameterInterfaceJson.cs
+++ b/src/vrcosclib.Test/Utility/OscAvatarParameterInterfaceJson.cs
@@ -3,4 +3,15 @@ using Newtonsoft.Json.Converters;
 
 namespace BuildSoft.VRChat.Osc.Test;
 
-public record class OscAvatarParameterInterfaceJson(string address, [JsonConverter(typeof(StringEnumConverter))] OscType type);
+public record class OscAvatarParameterInterfaceJson
+{
+    public string address;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public OscType type;
+    public OscAvatarParameterInterfaceJson(string address, OscType type)
+    {
+        this.address = address;
+        this.type = type;
+    }
+}

--- a/src/vrcosclib.Test/Utility/OscAvatarParameterJson.cs
+++ b/src/vrcosclib.Test/Utility/OscAvatarParameterJson.cs
@@ -3,8 +3,19 @@
 namespace BuildSoft.VRChat.Osc.Test;
 
 [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-public record class OscAvatarParameterJson(string name, OscAvatarParameterInterfaceJson? input, OscAvatarParameterInterfaceJson? output)
+public record class OscAvatarParameterJson
 {
+    public string name;
+    public OscAvatarParameterInterfaceJson? input;
+    public OscAvatarParameterInterfaceJson? output;
+
+    public OscAvatarParameterJson(string name, OscAvatarParameterInterfaceJson? input, OscAvatarParameterInterfaceJson? output)
+    {
+        this.name = name;
+        this.input = input;
+        this.output = output;
+    }
+
     public OscAvatarParameterJson(string name, OscType type, bool hasInput = true)
         : this(name,
               input: hasInput ? new(OscConst.AvatarParameterAddressSpace + name, type) : null,

--- a/src/vrcosclib.Test/vrcosclib.Test.csproj
+++ b/src/vrcosclib.Test/vrcosclib.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
     <Nullable>enable</Nullable>
     <RootNamespace>BuildSoft.VRChat.Osc.Test</RootNamespace>
     <LangVersion>10.0</LangVersion>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/src/vrcosclib.Test/vrcosclib.Test.csproj
+++ b/src/vrcosclib.Test/vrcosclib.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">net6.0;net461</TargetFrameworks>
+    <TargetFramework Condition="!$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>BuildSoft.VRChat.Osc.Test</RootNamespace>
     <LangVersion>10.0</LangVersion>

--- a/src/vrcosclib/Avatar/OscAvatarParametorContainer.cs
+++ b/src/vrcosclib/Avatar/OscAvatarParametorContainer.cs
@@ -118,7 +118,7 @@ public class OscAvatarParametorContainer : IReadOnlyDictionary<string, object?>
                     continue;
                 }
 
-                string baseName = paramName[..^info.Suffix.Length];
+                string baseName = paramName.Substring(0, paramName.Length - info.Suffix.Length);
                 int count = dictionay.ContainsKey(baseName) ? dictionay[baseName] + 1 : 1;
                 dictionay[baseName] = count;
 
@@ -180,7 +180,11 @@ public class OscAvatarParametorContainer : IReadOnlyDictionary<string, object?>
 
     public bool ContainsKey(string key) => Items.Any(param => param.Name == key);
 
-    public bool TryGetValue(string key, [NotNullWhen(true)] out object? value)
+    public bool TryGetValue(string key,
+#if NETSTANDARD2_1_OR_GREATER
+    [NotNullWhen(true)] 
+#endif
+    out object? value)
     {
         var param = Items.FirstOrDefault();
         if (param == null)
@@ -197,7 +201,7 @@ public class OscAvatarParametorContainer : IReadOnlyDictionary<string, object?>
     #region Events
     private void GetValueCallback(IReadOnlyOscParameterCollection sender, ParameterChangedEventArgs e)
     {
-        var name = e.Address[OscConst.AvatarParameterAddressSpace.Length..];
+        var name = e.Address.Substring(OscConst.AvatarParameterAddressSpace.Length);
         OnParameterChanged(Get(name), e);
     }
 

--- a/src/vrcosclib/Avatar/OscPhysBone.cs
+++ b/src/vrcosclib/Avatar/OscPhysBone.cs
@@ -89,7 +89,7 @@ public class OscPhysBone
 
     private void GetValueCallback(IReadOnlyOscParameterCollection sender, ParameterChangedEventArgs e)
     {
-        var name = e.Address[OscConst.AvatarParameterAddressSpace.Length..];
+        var name = e.Address.Substring(OscConst.AvatarParameterAddressSpace.Length);
         OnParameterChanged(_parameters.Get(name), e);
     }
 

--- a/src/vrcosclib/Collections/OscParameterCollection.cs
+++ b/src/vrcosclib/Collections/OscParameterCollection.cs
@@ -63,12 +63,17 @@ public class OscParameterCollection : IDictionary<string, object?>, IReadOnlyOsc
 
     public bool Remove(string key)
     {
-        bool removed = _items.Remove(key, out var value);
-        if (removed)
+        var item = _items;
+        if (item.TryGetValue(key, out var value))
         {
-            OnValueChanged(new ParameterChangedEventArgs(value, null, key, ValueChangedReason.Removed));
+            bool removed = item.Remove(key);
+            if (removed)
+            {
+                OnValueChanged(new ParameterChangedEventArgs(value, null, key, ValueChangedReason.Removed));
+            }
+            return removed;
         }
-        return removed;
+        return false;
     }
 
     public bool TryGetValue(string key, out object? value) => _items.TryGetValue(key, out value);

--- a/src/vrcosclib/Inputs/OscInput.cs
+++ b/src/vrcosclib/Inputs/OscInput.cs
@@ -1,4 +1,6 @@
-﻿namespace BuildSoft.VRChat.Osc.Input;
+﻿using BuildSoft.VRChat.Osc.Utility;
+
+namespace BuildSoft.VRChat.Osc.Input;
 
 public static class OscInput
 {
@@ -20,7 +22,7 @@ public static class OscInput
 
     public static void Send(this OscAxisInput content, float value)
     {
-        OscParameter.SendValue(content.CreateAddress(), Math.Clamp(value, -1f, 1f));
+        OscParameter.SendValue(content.CreateAddress(), MathHelper.Clamp(value, -1f, 1f));
     }
 
     public static string CreateAddress(this OscButtonInput content)

--- a/src/vrcosclib/Utility/MathHelper.cs
+++ b/src/vrcosclib/Utility/MathHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuildSoft.VRChat.Osc.Utility;
+internal static class MathHelper
+{
+    public static T Clamp<T>(T value, T min, T max) where T : IComparable<T>
+    {
+        if (min.CompareTo(max) > 0)
+        {
+            throw new ArgumentException();
+        }
+        if (value.CompareTo(min) < 0)
+        {
+            return min;
+        }
+        if (value.CompareTo(max) > 0)
+        {
+            return max;
+        }
+        return value;
+    }
+}

--- a/src/vrcosclib/vrcosclib.csproj
+++ b/src/vrcosclib/vrcosclib.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
 	<RootNamespace>BuildSoft.VRChat.Osc</RootNamespace>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     
     <BaseOutputPath>..\..\bin</BaseOutputPath>
-
+    
     <PackageId>VRCOscLib</PackageId>
     <Version>1.2.1</Version>
     <Authors>ChanyaKushima</Authors>
@@ -18,10 +18,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BuildSoft.OscCore" Version="1.0.5" />
+    <PackageReference Include="BuildSoft.OscCore" Version="1.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
+  
+  <Target Name="GetTargetPath" Returns="@(_FakeOutputPath)">
+    <ItemGroup>
+      <_FakeOutputPath Include="$(MSBuildProjectDirectory)\$(PackageOutputPath)\$(AssemblyName).dll" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Corresponds code to .NET Standard 2.0 so that it can be used in .NET Framework (>=4.6.1).

Currently, .NET Framework cannot be tested, but NUnit Package is the cause, so no fix is required.