### PR TITLE
Fixes for null parameter

### DIFF
--- a/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
+++ b/src/vrcosclib.Test/Collections/OscParameterCollectionTests.cs
@@ -207,6 +207,7 @@ public class OscParameterCollectionTests
                      break;
              }
          };
+        parameters.ValueChanged += (sender, e) => throw new Exception();
         return parameters;
     }
 
@@ -272,5 +273,22 @@ public class OscParameterCollectionTests
         pararmeters["/address/to/parameter2"] = 10f;
         pararmeters["/address/to/parameter3"] = false;
         Assert.DoesNotThrow(() => pararmeters.OrderBy(v => v.Key).ToArray());
+    }
+
+
+    [Test]
+    public void OnValueChangedByAddress_IgnoreExceptionTest()
+    {
+        var parameters = CreateParameterCollectionForTest();
+        int calledCount = 0;
+
+        const string Address = "/address/to/parameter";
+        parameters.AddValueChangedEventByAddress(Address, (_, _) => calledCount++);
+        parameters.AddValueChangedEventByAddress(Address, (_, _) => throw new Exception());
+        parameters.AddValueChangedEventByAddress(Address, (_, _) => calledCount++);
+
+        parameters[Address] = 1;
+
+        Assert.AreEqual(2, calledCount);
     }
 }

--- a/src/vrcosclib/Collections/OscParameterCollection.cs
+++ b/src/vrcosclib/Collections/OscParameterCollection.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
-
+using BuildSoft.VRChat.Osc.Delegate;
 using ParamChangedHandler = BuildSoft.VRChat.Osc.OscParameterChangedEventHandler<BuildSoft.VRChat.Osc.IReadOnlyOscParameterCollection>;
 
 namespace BuildSoft.VRChat.Osc;
@@ -101,7 +101,7 @@ public class OscParameterCollection : IDictionary<string, object?>, IReadOnlyOsc
 
     protected void OnValueChanged(ParameterChangedEventArgs args)
     {
-        ValueChanged?.Invoke(this, args);
+        ValueChanged?.DynamicInvokeAllWithoutException(this, args);
         OnValueChangedByAddress(args);
     }
 
@@ -114,7 +114,14 @@ public class OscParameterCollection : IDictionary<string, object?>, IReadOnlyOsc
         var handlers = list.ToArray();
         for (int i = 0; i < handlers.Length; i++)
         {
-            handlers[i].Invoke(this, args);
+            try
+            {
+                handlers[i].Invoke(this, args);
+            }
+            catch (Exception)
+            {
+                // eat exception
+            }
         }
     }
 

--- a/src/vrcosclib/Delegate/EventDelegateExtension.cs
+++ b/src/vrcosclib/Delegate/EventDelegateExtension.cs
@@ -1,0 +1,19 @@
+﻿namespace BuildSoft.VRChat.Osc.Delegate;
+
+internal static class EventDelegateExtension
+{
+    public static void DynamicInvokeAllWithoutException<T>(this T @delegate, params object[] args) where T : System.Delegate
+    {
+        foreach (var item in @delegate.GetInvocationList())
+        {
+            try
+            {
+                item.DynamicInvoke(args);
+            }
+            catch (Exception)
+            {
+                // eat exception
+            }
+        }
+    }
+}


### PR DESCRIPTION
Heyo,

there was a little bug which caused the osc params to not be updated anymore.

In my case there was an Animator param that has been updated, which was not in the VRC params.
This method just ignores null values and doesn´t fire the update event ;)